### PR TITLE
修正示例文档语法错误

### DIFF
--- a/docs/codelab.md
+++ b/docs/codelab.md
@@ -133,7 +133,7 @@ type WeiboScoringFields struct {
 type WeiboScoringCriteria struct {
 }
 
-func (criteria WeiboScoringCriteria) Score(
+func (criteria WeiboScoringCriteria) Score {
         doc types.IndexedDocument, fields interface{}) []float32 {
         if reflect.TypeOf(fields) != reflect.TypeOf(WeiboScoringFields{}) {
                 return []float32{}


### PR DESCRIPTION
示例文档中的”(“，应该是“{”